### PR TITLE
Added code to properly propogate custom options to decodeResponse()

### DIFF
--- a/lib/AdobeMarketingCloud/HttpClient.php
+++ b/lib/AdobeMarketingCloud/HttpClient.php
@@ -206,12 +206,16 @@ abstract class HttpClient implements HttpClientInterface
      *
      * @return  array   the response
      */
-    protected function decodeResponse($response)
+    protected function decodeResponse($response, $options = array())
     {
-        switch ($this->options['format'])
+        if (count($options) == 0) {
+            $options = $this->options;
+        }
+
+        switch ($options['format'])
         {
             case 'json':
-                if ((null === $json = json_decode($response['response'], true)) && ($this->options['debug'] === true)) {
+                if ((null === $json = json_decode($response['response'], true)) && ($options['debug'] === true)) {
                     throw new Exception("Response is not in JSON format: \n\n".print_r($response, true));
                 }
                 return $json;
@@ -229,6 +233,6 @@ abstract class HttpClient implements HttpClientInterface
                 return $response['response'];
         }
 
-        throw new \LogicException(__CLASS__.' only supports json, json, xml, and xspf formats, '.$this->options['format'].' given.');
+        throw new \LogicException(__CLASS__.' only supports json, json, xml, and xspf formats, '.$options['format'].' given.');
     }
 }

--- a/lib/AdobeMarketingCloud/HttpClient/Curl.php
+++ b/lib/AdobeMarketingCloud/HttpClient/Curl.php
@@ -138,14 +138,14 @@ class Curl extends HttpClient
      *
      * @return  array   the response
      */
-    protected function decodeResponse($response)
+    protected function decodeResponse($response, $options = array())
     {
         // "false" means a failed curl request
         if (false === $response['response']) {
             $this->debug(print_r($response, true));
             return false;
         }
-        return parent::decodeResponse($response);
+        return parent::decodeResponse($response, $options);
     }
 
     protected function doCurlCall(array $curlOptions)


### PR DESCRIPTION
The method HttpClient.request() is already passing the options parameter to decodeResponse, but the actual implementation of the function doesn't expect that parameter and it is ignored.

I've added that parameter and tweaked the switch() condition to check $options instead of $this->options.