### PR TITLE
removing mt_rand from auth use cases

### DIFF
--- a/lib/AdobeMarketingCloud/Auth/Wsse.php
+++ b/lib/AdobeMarketingCloud/Auth/Wsse.php
@@ -64,11 +64,11 @@ class Wsse implements AuthInterface
     protected function getNonce()
     {
         return sprintf('%04x%04x-%04x-%03x4-%04x-%04x%04x%04x',
-            mt_rand(0, 65535), mt_rand(0, 65535),
-            mt_rand(0, 65535),
-            mt_rand(0, 4095),
-            bindec(substr_replace(sprintf('%016b', mt_rand(0, 65535)), '01', 6, 2)),
-            mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535)
+            random_int(0, 65535), random_int(0, 65535),
+            random_int(0, 65535),
+            random_int(0, 4095),
+            bindec(substr_replace(sprintf('%016b', random_int(0, 65535)), '01', 6, 2)),
+            random_int(0, 65535), random_int(0, 65535), random_int(0, 65535)
         );
     }
 }


### PR DESCRIPTION
mt_rand is cryptographically insecure and needs to be replaces by the random_int function from php7